### PR TITLE
First NDLAr Configuration File

### DIFF
--- a/config/ndlar/ndlar_full_chain_flash_nersc_240819.cfg
+++ b/config/ndlar/ndlar_full_chain_flash_nersc_240819.cfg
@@ -91,7 +91,7 @@ io:
 # Model configuration
 model:
   name: full_chain
-  weight_path: /global/cfs/cdirs/dune/www/data/2x2/simulation/mlreco_weights/2x2_snapshot-3999.ckpt
+  weight_path: /global/cfs/cdirs/dune/www/data/2x2/simulation/mlreco_weights/2x2_240819_snapshot.ckpt
   to_numpy: true
 
   network_input:

--- a/config/ndlar/ndlar_full_chain_flash_nersc_240819.cfg
+++ b/config/ndlar/ndlar_full_chain_flash_nersc_240819.cfg
@@ -482,11 +482,11 @@ post:
     update_primaries: false
     priority: 1
   containment:
-    detector: 2x2
+    detector: dunend
     margin: 5.0
     mode: detector
   fiducial:
-    detector: 2x2
+    detector: dunend
     margin: 15.0
     mode: detector
   children_count:

--- a/config/ndlar/ndlar_full_chain_flash_nersc_240819.cfg
+++ b/config/ndlar/ndlar_full_chain_flash_nersc_240819.cfg
@@ -31,6 +31,7 @@ io:
           parser: particle_points
           sparse_event: sparse3d_pcluster
           particle_event: particle_pcluster
+          include_point_tagging: false
         clust_label:
           parser: cluster3d
           cluster_event: cluster3d_pcluster
@@ -65,6 +66,9 @@ io:
         trigger:
           parser: trigger
           trigger_event: trigger_base
+        flashes:
+          parser: flash
+          flash_event: opflash_light
 
   writer:
     name: hdf5
@@ -74,6 +78,7 @@ io:
       - run_info
       - meta
       - trigger
+      - flashes
       - points
       - points_label
       - depositions
@@ -136,7 +141,7 @@ model:
           momentum: 0.01
   
       ppn:
-        classify_endpoints: true
+        classify_endpoints: false
   
     uresnet_ppn_loss:
       uresnet_loss:

--- a/config/ndlar/ndlar_full_chain_nersc_240830.cfg
+++ b/config/ndlar/ndlar_full_chain_nersc_240830.cfg
@@ -1,0 +1,494 @@
+# Base configuration
+base:
+  world_size: 1
+  iterations: -1
+  seed: 0
+  dtype: float32
+  unwrap: true
+  log_dir: logs
+  prefix_log: true
+  overwrite_log: true
+  log_step: 1
+
+# IO configuration
+io:
+  loader:
+    batch_size: 16
+    shuffle: false
+    num_workers: 4
+    collate_fn: all
+    dataset:
+      name: larcv
+      file_keys: null
+      schema:
+        data:
+          parser: sparse3d
+          sparse_event: sparse3d_pcluster
+        seg_label:
+          parser: sparse3d
+          sparse_event: sparse3d_pcluster_semantics
+        ppn_label:
+          parser: particle_points
+          sparse_event: sparse3d_pcluster
+          particle_event: particle_pcluster
+        clust_label:
+          parser: cluster3d
+          cluster_event: cluster3d_pcluster
+          particle_event: particle_pcluster
+          neutrino_event: neutrino_mc_truth
+          sparse_semantics_event: sparse3d_pcluster_semantics
+          add_particle_info: true
+          clean_data: true
+        coord_label:
+          parser: particle_coords
+          particle_event: particle_pcluster
+          cluster_event: cluster3d_pcluster
+        graph_label:
+          parser: particle_graph
+          particle_event: particle_pcluster
+        particles:
+          parser: particle
+          particle_event: particle_pcluster
+          neutrino_event: neutrino_mc_truth
+          cluster_event: cluster3d_pcluster
+          skip_empty: true
+        neutrinos:
+          parser: neutrino
+          neutrino_event: neutrino_mc_truth
+          cluster_event: cluster3d_pcluster
+        meta:
+          parser: meta
+          sparse_event: sparse3d_pcluster
+        run_info:
+          parser: run_info
+          sparse_event: sparse3d_pcluster
+        trigger:
+          parser: trigger
+          trigger_event: trigger_base
+
+  writer:
+    name: hdf5
+    file_name: null
+    overwrite: true
+    keys:
+      - run_info
+      - meta
+      - trigger
+      - points
+      - points_label
+      - depositions
+      - depositions_label
+      - reco_particles
+      - truth_particles
+      - reco_interactions
+      - truth_interactions
+
+# Model configuration
+model:
+  name: full_chain
+  weight_path: /global/cfs/cdirs/dune/www/data/2x2/simulation/mlreco_weights/2x2_snapshot-3999.ckpt
+  to_numpy: true
+
+  network_input:
+    data: data
+    seg_label: seg_label
+    clust_label: clust_label
+
+  loss_input:
+    seg_label: seg_label
+    ppn_label: ppn_label
+    clust_label: clust_label
+    coord_label: coord_label
+
+  modules:
+    # General chain configuration
+    chain:
+      deghosting: null
+      charge_rescaling: null
+      segmentation: uresnet
+      point_proposal: ppn
+      fragmentation: graph_spice
+      shower_aggregation: grappa
+      shower_primary: grappa
+      track_aggregation: grappa
+      particle_aggregation: null
+      inter_aggregation: grappa
+      particle_identification: grappa
+      primary_identification: grappa
+      orientation_identification: grappa
+      calibration: null
+
+    # Semantic segmentation + point proposal
+    uresnet_ppn:
+      uresnet:
+        num_input: 1
+        num_classes: 5
+        filters: 32
+        depth: 5
+        reps: 2
+        allow_bias: false
+        activation:
+          name: lrelu
+          negative_slope: 0.33
+        norm_layer:
+          name: batch_norm
+          eps: 0.0001
+          momentum: 0.01
+  
+      ppn:
+        classify_endpoints: true
+  
+    uresnet_ppn_loss:
+      uresnet_loss:
+        balance_loss: false
+  
+      ppn_loss:
+        mask_loss: CE
+        resolution: 5.0
+
+    # Dense clustering
+    graph_spice:
+      shapes: [shower, track, michel, delta]
+      use_raw_features: true
+      invert: true
+      make_clusters: true
+      embedder:
+        spatial_embedding_dim: 3
+        feature_embedding_dim: 16
+        occupancy_mode: softplus
+        covariance_mode: softplus
+        uresnet:
+          num_input: 4 # 1 feature + 3 normalized coords
+          filters: 32
+          input_kernel: 5
+          depth: 5
+          reps: 2
+          spatial_size: 31231
+          allow_bias: false
+          activation:
+            name: lrelu
+            negative_slope: 0.33
+          norm_layer:
+            name: batch_norm
+            eps: 0.0001
+            momentum: 0.01
+      kernel:
+        name: bilinear
+        num_features: 32
+      constructor:
+        edge_threshold: 0.1
+        min_size: 3
+        label_edges: true
+        graph:
+          name: radius
+          r: 1.9
+        orphan:
+          mode: radius
+          radius: 1.9
+          iterate: true
+          assign_all: true
+
+    graph_spice_loss:
+      name: edge
+      loss: binary_log_dice_ce
+
+    # Shower fragment aggregation + shower primary identification
+    grappa_shower:
+      nodes:
+        source: cluster
+        shapes: [shower, michel, delta]
+        min_size: -1
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: [340, 0, 340, 340, 0, 0, 0, 17, 0, 17]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred: 2
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_shower_loss:
+      node_loss:
+        name: shower_primary
+        high_purity: true
+        use_group_pred: true
+      edge_loss:
+        name: channel
+        target: group
+        high_purity: true
+
+    # Track aggregation
+    grappa_track:
+      nodes:
+        source: cluster
+        shapes: [track]
+        min_size: -1
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: 67
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: false
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 32 # 16 (geo) + 2 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_track_loss:
+      edge_loss:
+        name: channel
+        target: group
+
+    # Interaction aggregation, PID, primary, orientation
+    grappa_inter:
+      nodes:
+        source: group
+        shapes: [shower, track, michel, delta]
+        min_size: -1
+        make_groups: true
+      graph:
+        name: complete
+        max_length: [340, 340, 0, 0, 17, 17, 17, 0, 0, 0]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred:
+          type: 6
+          primary: 2
+          orient: 2
+          #momentum: 1
+          #vertex: 5
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_inter_loss:
+      node_loss:
+        type:
+          name: class
+          target: pid
+          loss: ce
+          balance_loss: true
+        primary:
+          name: class
+          target: inter_primary
+          loss: ce
+          balance_loss: true
+        orient:
+          name: orient
+          loss: ce
+        #momentum:
+        #  name: reg
+        #  target: momentum
+        #  loss: berhu
+        #vertex:
+        #  name: vertex
+        #  primary_loss: ce
+        #  balance_primary_loss: true
+        #  regression_loss: mse
+        #  only_contained: true
+        #  normalize_positions: true
+        #  use_anchor_points: true
+        #  return_vertex_labels: true
+        #  detector: icarus
+      edge_loss:
+        name: channel
+        target: interaction
+
+# Build output representations
+build:
+  mode: both
+  units: cm
+  fragments: false
+  particles: true
+  interactions: true
+  
+# Run post-processors
+post:
+  shape_logic:
+    enforce_pid: true
+    enforce_primary: true
+    priority: 3
+  #particle_threshold:
+  #  track_pid_thresholds:
+  #    4: 0.85
+  #    2: 0.1
+  #    3: 0.5
+  #    5: 0.0
+  #  shower_pid_thresholds:
+  #    0: 0.5 
+  #    1: 0.0
+  #  primary_threshold: 0.1
+  #  priority: 2
+  #track_extrema:
+  #  method: gradient
+  #  priority: 2
+  direction:
+    obj_type: particle
+    optimize: true
+    run_mode: both
+    priority: 1
+  calo_ke:
+    run_mode: reco
+    scaling: 1.
+    shower_fudge: 1/0.83
+    priority: 1
+  csda_ke:
+    run_mode: reco
+    tracking_mode: step_next
+    segment_length: 5.0
+    priority: 1
+  mcs_ke:
+    run_mode: reco
+    tracking_mode: bin_pca
+    segment_length: 5.0
+    priority: 1
+  topology_threshold:
+    ke_thresholds:
+      4: 50
+      default: 25
+  vertex:
+    use_primaries: true
+    update_primaries: false
+    priority: 1
+  containment:
+    detector: 2x2
+    margin: 5.0
+    mode: detector
+  fiducial:
+    detector: 2x2
+    margin: 15.0
+    mode: detector
+  children_count:
+    mode: shape
+  match:
+    match_mode: both
+    ghost: false
+    fragment: false
+    particle: true
+    interaction: true


### PR DESCRIPTION
Adding first NDLAr configuration file for running at NERSC. This configuration is an adaptation of [2x2_full_chain_flash_240819.cfg](https://github.com/DeepLearnPhysics/spine_prod/blob/main/config/2x2/2x2_full_chain_flash_240819.cfg) with a NERSC weights path and several tweaks made by Kazu to get it up and running for NDLAr. The `diff` of the 2x2 config and this new config is below. It has been tested in `MicroProdN1.1`. Note that the weights in the 2x2 config were already out of date in `spine_prod` at the time of doing the `diff` which is why the weight file name and not just the path changes.

```
> diff ndlar_full_chain_flash_nersc_240819.cfg ../2x2/2x2_full_chain_flash_240819.cfg 
16c16
<     batch_size: 16
---
>     batch_size: 64
18c18
<     num_workers: 4
---
>     num_workers: 8
94c94
<   weight_path: /global/cfs/cdirs/dune/www/data/2x2/simulation/mlreco_weights/2x2_240819_snapshot.ckpt
---
>   weight_path: /sdf/data/neutrino/2x2/spine/train/mpvmpr_v2/weights/full_chain/default/snapshot-3999.ckpt
171c171
<           spatial_size: 31231
---
>           spatial_size: 320
210c210
<         max_length: [340, 0, 340, 340, 0, 0, 0, 17, 0, 17]
---
>         max_length: [500, 0, 500, 500, 0, 0, 0, 25, 0, 25]
279c279
<         max_length: 67
---
>         max_length: 100
341c341
<         max_length: [340, 340, 0, 0, 17, 17, 17, 0, 0, 0]
---
>         max_length: [500, 500, 0, 0, 25, 25, 25, 0, 0, 0]
```