### PR TITLE
Add new weights for SBND

### DIFF
--- a/config/sbnd/README.md
+++ b/config/sbnd/README.md
@@ -2,6 +2,36 @@
 
 The configurations below have been trained on SBND MPV/MPR datasets. This summary is divided by training/validation dataset.
 
+## Configurations for MPVMPR v02
+
+```shell
+sbnd_full_chain_250328.cfg
+sbnd_full_chain_data_250328.cfg
+```
+
+These weights have been trained using the following files at Polaris:
+- Training set: `/lus/eagle/projects/neutrinoGPU/bearc/simulation/mpvmpr_v02/train/files.txt` (255k)
+- Test set: `/lus/eagle/projects/neutrinoGPU/bearc/simulation/mpvmpr_v02/test/larcv/files.txt` (68k)
+
+Training samples MPVMPR using `sbndcode v10_04_01` which can be found [here](https://github.com/SBNSoftware/sbndcode/tree/v10_04_01) . The training samples are generated using the following fcls:
+```
+run_mpvmpr_sbnd.fcl
+g4_sce_lite.fcl
+detsim_sce_lite.fcl
+reco1_mpvmpr.fcl
+```
+
+The following modifications were made to the `sbndcode` configuration:
+- Ghost labeling parameters - [Supera PR #54](https://github.com/DeepLearnPhysics/Supera/pull/54)
+- Doublets are used - [sbndcode PR #661](https://github.com/SBNSoftware/sbndcode/pull/661)
+- Updated clock - [sbndcode PR #645](https://github.com/SBNSoftware/sbndcode/pull/645)
+- `larwirecell` patch - [larwirecell PR #55](https://github.com/LArSoft/larwirecell/pull/55)
+
+Description:
+  - UResNet + PPN + gSPICE + GrapPAs (track + shower + interaction)
+  - Class-weighted loss on PID predictions
+  - The `*_data_*` declination is tailored for data (no labels)
+
 ## Configurations for MPV/MPR v01
 
 These weights have been trained/validated using the following files:

--- a/config/sbnd/README.md
+++ b/config/sbnd/README.md
@@ -13,6 +13,8 @@ These weights have been trained using the following files at Polaris:
 - Training set: `/lus/eagle/projects/neutrinoGPU/bearc/simulation/mpvmpr_v02/train/files.txt` (255k)
 - Test set: `/lus/eagle/projects/neutrinoGPU/bearc/simulation/mpvmpr_v02/test/larcv/files.txt` (68k)
 
+...using the configs in the [sbnd_spine_train](https://github.com/bear-is-asleep/sbnd_spine_train/tree/master) repo.
+
 Training samples MPVMPR using `sbndcode v10_04_01` which can be found [here](https://github.com/SBNSoftware/sbndcode/tree/v10_04_01) . The training samples are generated using the following fcls:
 ```
 run_mpvmpr_sbnd.fcl

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -1,0 +1,553 @@
+# Base configuration
+base:
+  world_size: 1
+  iterations: -1
+  seed: 0
+  dtype: float32
+  unwrap: true
+  log_dir: logs
+  prefix_log: true
+  overwrite_log: true
+  log_step: 1
+  split_output: true
+
+# IO configuration
+io:
+  loader:
+    batch_size: 16
+    shuffle: false
+    num_workers: 8
+    collate_fn: all
+    dataset:
+      name: larcv
+      file_keys: null
+      schema:
+        data:
+          parser: sparse3d
+          sparse_event_list:
+            - sparse3d_reco
+            - sparse3d_reco_chi2
+            - sparse3d_reco_hit_charge0
+            - sparse3d_reco_hit_charge1
+            - sparse3d_reco_hit_charge2
+            - sparse3d_reco_hit_key0
+            - sparse3d_reco_hit_key1
+            - sparse3d_reco_hit_key2
+        sources:
+          parser: sparse3d
+          sparse_event_list:
+            - sparse3d_reco_cryo
+            - sparse3d_reco_tpc
+          feature_only: true
+        seg_label:
+          parser: sparse3d
+          sparse_event: sparse3d_pcluster_semantics_ghost
+        ppn_label:
+          parser: particle_points
+          sparse_event: sparse3d_pcluster
+          particle_event: particle_corrected
+          include_point_tagging: false
+        clust_label:
+          parser: cluster3d
+          cluster_event: cluster3d_pcluster
+          particle_event: particle_corrected
+          neutrino_event: neutrino_mpv
+          sparse_semantics_event: sparse3d_pcluster_semantics
+          add_particle_info: true
+          clean_data: true
+        clust_label_g4:
+          parser: cluster3d
+          cluster_event: cluster3d_sed
+          particle_event: particle_corrected
+          add_particle_info: true
+        charge_label:
+          parser: sparse3d
+          sparse_event: sparse3d_reco_rescaled
+        coord_label:
+          parser: particle_coords
+          particle_event: particle_corrected
+          cluster_event: cluster3d_pcluster
+        graph_label:
+          parser: particle_graph
+          particle_event: particle_corrected
+        particles:
+          parser: particle
+          particle_event: particle_corrected
+          neutrino_event: neutrino_mpv
+          cluster_event: cluster3d_pcluster
+        neutrinos:
+          parser: neutrino
+          neutrino_event: neutrino_mpv
+          cluster_event: cluster3d_pcluster
+        flashes:
+          parser: flash
+          flash_event_list:
+            - opflash_tpc0
+            - opflash_tpc1
+        flashes_xa:
+          parser: flash
+          flash_event_list:
+            - opflash_tpc0xa
+            - opflash_tpc1xa
+        meta:
+          parser: meta
+          sparse_event: sparse3d_pcluster
+        run_info:
+          parser: run_info
+          sparse_event: sparse3d_pcluster
+
+  writer:
+    name: hdf5
+    file_name: null
+    overwrite: true
+    keys:
+      - run_info
+      - meta
+      - points
+      - points_label
+      - points_g4
+      - depositions
+      - depositions_label
+      - depositions_q_label
+      - depositions_g4
+      - sources
+      - sources_label
+      - reco_particles
+      - truth_particles
+      - reco_interactions
+      - truth_interactions
+      - flashes
+      - flashes_xa
+
+# Model configuration
+model:
+  name: full_chain
+  weight_path: /sdf/data/neutrino/sbnd/train/mpvmpr_v02/weights/full_chain/restrict/snapshot-4999.ckpt #s3df
+  #weight_path: /lus/eagle/projects/neutrinoGPU/bearc/spine_weights/mpvmpr_v02/weights/full_chain/grappa_inter/default/snapshot-4999.ckpt #polaris
+  to_numpy: true
+
+  network_input:
+    data: data
+    sources: sources
+    seg_label: seg_label
+
+  modules:
+    # General chain configuration
+    chain:
+      deghosting: uresnet
+      charge_rescaling: average
+      segmentation: uresnet
+      point_proposal: ppn
+      fragmentation: graph_spice
+      shower_aggregation: grappa
+      shower_primary: grappa
+      track_aggregation: grappa
+      particle_aggregation: null
+      inter_aggregation: grappa
+      particle_identification: grappa
+      primary_identification: grappa
+      orientation_identification: grappa
+      calibration: null
+
+    # Deghosting
+    uresnet_deghost:
+      num_input: 2
+      num_classes: 2
+      filters: 32
+      depth: 5
+      reps: 2
+      allow_bias: false
+      activation:
+        name: lrelu
+        negative_slope: 0.33
+      norm_layer:
+        name: batch_norm
+        eps: 0.0001
+        momentum: 0.01
+
+    uresnet_deghost_loss:
+      balance_loss: false
+
+    # Semantic segmentation + point proposal
+    uresnet_ppn:
+      uresnet:
+        num_input: 1
+        num_classes: 5
+        filters: 32
+        depth: 5
+        reps: 2
+        allow_bias: false
+        activation:
+          name: lrelu
+          negative_slope: 0.33
+        norm_layer:
+          name: batch_norm
+          eps: 0.0001
+          momentum: 0.01
+  
+      ppn:
+        classify_endpoints: false
+  
+    uresnet_ppn_loss:
+      uresnet_loss:
+        balance_loss: false
+  
+      ppn_loss:
+        mask_loss: CE
+        resolution: 5.0
+        restrict_to_clusters: true
+
+    # Adapt labels to the segmentation predictions
+    adapt_labels:
+      break_eps: 2.1
+      break_metric: chebyshev
+
+    # Fragmentation
+    graph_spice:
+      shapes: [shower, track, michel, delta]
+      use_raw_features: true
+      invert: true
+      make_clusters: true
+      embedder:
+        spatial_embedding_dim: 3
+        feature_embedding_dim: 16
+        occupancy_mode: softplus
+        covariance_mode: softplus
+        uresnet:
+          num_input: 4 # 1 feature + 3 normalized coords
+          filters: 32
+          input_kernel: 5
+          depth: 5
+          reps: 2
+          spatial_size: 6144
+          allow_bias: false
+          activation:
+            name: lrelu
+            negative_slope: 0.33
+          norm_layer:
+            name: batch_norm
+            eps: 0.0001
+            momentum: 0.01
+      kernel:
+        name: bilinear
+        num_features: 32
+      constructor:
+        edge_threshold: 0.1
+        min_size: 3
+        label_edges: false
+        graph:
+          name: radius
+          r: 1.9
+        orphan:
+          mode: radius
+          radius: 1.9
+          iterate: true
+          assign_all: true
+
+    graph_spice_loss:
+      name: edge
+      loss: binary_log_dice_ce
+
+    # Shower fragment aggregation + shower primary identification
+    grappa_shower:
+      nodes:
+        source: cluster
+        shapes: [shower, michel, delta]
+        min_size: -1
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: [500, 0, 500, 500, 0, 0, 0, 25, 0, 25]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred: 2
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_shower_loss:
+      node_loss:
+        name: shower_primary
+        high_purity: true
+        use_group_pred: true
+      edge_loss:
+        name: channel
+        target: group
+        high_purity: true
+
+    # Track aggregation
+    grappa_track:
+      nodes:
+        source: cluster
+        shapes: [track]
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: 100
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: false
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 32 # 16 (geo) + 2 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_track_loss:
+      edge_loss:
+        name: channel
+        target: group
+
+    # Interaction aggregation, PID, primary, orientation
+    grappa_inter:
+      nodes:
+        source: group
+        shapes: [shower, track, michel, delta]
+        min_size: -1
+        make_groups: true
+      graph:
+        name: complete
+        max_length: [500, 500, 0, 0, 25, 25, 25, 0, 0, 0]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred:
+          type: 5
+          primary: 2
+          orient: 2
+          #momentum: 1
+          #vertex: 5
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_inter_loss:
+      node_loss:
+        type:
+          name: class
+          target: pid
+          loss: ce
+          balance_loss: true
+        primary:
+          name: class
+          target: inter_primary
+          loss: ce
+          balance_loss: true
+        orient:
+          name: orient
+          loss: ce
+      edge_loss:
+        name: channel
+        target: interaction
+
+# Build output representations
+build:
+  mode: both
+  units: cm
+  fragments: false
+  particles: true
+  interactions: true
+  
+# Run post-processors
+post:
+  flash_match:
+    flash_key: flashes
+    volume: tpc
+    detector: sbnd
+    method: likelihood
+    cfg: flashmatch_240918.cfg
+    scaling: 1./555. # If reprocessing data that's already been scaled, use 1
+    alpha: 0.21 # Light yield calculation - https://arxiv.org/pdf/1909.07920
+    recombination_mip: 0.6 # 0.65 used in studies - https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=38164
+    priority: 3
+  shape_logic:
+    enforce_pid: true
+    enforce_primary: true
+    priority: 3
+  apply_calibrations:
+    geometry:
+      detector: sbnd
+    gain:
+      gain: [57.,57.] #from mc #[52.356,52.356] #from pandora data
+    recombination:
+      efield: 0.5 # kV/cm
+      model: mbox
+    lifetime:
+      lifetime: [50000, 50000] #us
+      driftv: [0.1563, 0.1563] #cm/us
+    priority: 2
+  direction:
+    obj_type: particle
+    optimize: true
+    run_mode: reco
+    priority: 1
+    neighborhood_radius: 60
+  calo_ke:
+    run_mode: both
+    scaling: 1.
+    shower_fudge: 1/0.77 # previous:  1/0.83
+    priority: 1
+  csda_ke:
+    run_mode: reco
+    tracking_mode: step_next
+    segment_length: 5.0
+    fill_per_pid: true
+    priority: 1
+  mcs_ke:
+    run_mode: reco
+    tracking_mode: bin_pca
+    segment_length: 14.0
+    fill_per_pid: true
+    priority: 1
+  containment:
+    detector: sbnd
+    mode: source
+    margin: 5.0
+    cathode_margin: -5.0
+    min_particle_sizes:
+      0: 25
+      1: 25
+    priority: 1
+  vertex:
+    use_primaries: true
+    update_primaries: false
+    priority: 1
+    run_mode: reco
+  topology_threshold:
+    ke_thresholds:
+      4: 50
+      default: 25
+  fiducial:
+    detector: sbnd
+    mode: module
+    margin: [[20,20],[20,20],[10,50]] # TODO: add 5cm pad either side of the cathode
+  children_count:
+    mode: shape
+  match:
+    match_mode: both
+    ghost: true
+    truth_point_mode: points
+    fragment: false
+    particle: true
+    interaction: true

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -1,0 +1,493 @@
+# Base configuration
+base:
+  world_size: 1
+  iterations: -1
+  seed: 0
+  dtype: float32
+  unwrap: true
+  log_dir: logs
+  prefix_log: true
+  overwrite_log: true
+  log_step: 1
+  split_output: true
+
+# IO configuration
+io:
+  loader:
+    batch_size: 16
+    shuffle: false
+    num_workers: 8
+    collate_fn: all
+    dataset:
+      name: larcv
+      file_keys: null
+      schema:
+        data:
+          parser: sparse3d
+          sparse_event_list:
+            - sparse3d_reco
+            - sparse3d_reco_chi2
+            - sparse3d_reco_hit_charge0
+            - sparse3d_reco_hit_charge1
+            - sparse3d_reco_hit_charge2
+            - sparse3d_reco_hit_key0
+            - sparse3d_reco_hit_key1
+            - sparse3d_reco_hit_key2
+        sources:
+          parser: sparse3d
+          sparse_event_list:
+            - sparse3d_reco_cryo
+            - sparse3d_reco_tpc
+          feature_only: true
+        flashes:
+          parser: flash
+          flash_event_list:
+            - opflash_tpc0
+            - opflash_tpc1
+        #flashes_xa:
+        #  parser: flash
+        #  flash_event_list:
+        #    - opflash_tpc0xa
+        #    - opflash_tpc1xa
+        meta:
+          parser: meta
+          sparse_event: sparse3d_reco
+        run_info:
+          parser: run_info
+          sparse_event: sparse3d_reco
+
+  writer:
+    name: hdf5
+    file_name: null
+    overwrite: true
+    keys:
+      - run_info
+      - meta
+      - points
+      - depositions
+      - sources
+      - reco_particles
+      - reco_interactions
+      - flashes
+      #- flashes_xa
+
+# Model configuration
+model:
+  name: full_chain
+  weight_path: /sdf/data/neutrino/sbnd/train/mpvmpr_v02/weights/full_chain/restrict/snapshot-4999.ckpt #s3df
+  #weight_path: /lus/eagle/projects/neutrinoGPU/bearc/spine_weights/mpvmpr_v02/weights/full_chain/grappa_inter/default/snapshot-4999.ckpt #polaris
+  to_numpy: true
+
+  network_input:
+    data: data
+    sources: sources
+
+  modules:
+    # General chain configuration
+    chain:
+      deghosting: uresnet
+      charge_rescaling: average
+      segmentation: uresnet
+      point_proposal: ppn
+      fragmentation: graph_spice
+      shower_aggregation: grappa
+      shower_primary: grappa
+      track_aggregation: grappa
+      particle_aggregation: null
+      inter_aggregation: grappa
+      particle_identification: grappa
+      primary_identification: grappa
+      orientation_identification: grappa
+      calibration: null
+
+    # Deghosting
+    uresnet_deghost:
+      num_input: 2
+      num_classes: 2
+      filters: 32
+      depth: 5
+      reps: 2
+      allow_bias: false
+      activation:
+        name: lrelu
+        negative_slope: 0.33
+      norm_layer:
+        name: batch_norm
+        eps: 0.0001
+        momentum: 0.01
+
+    uresnet_deghost_loss:
+      balance_loss: false
+
+    # Semantic segmentation + point proposal
+    uresnet_ppn:
+      uresnet:
+        num_input: 1
+        num_classes: 5
+        filters: 32
+        depth: 5
+        reps: 2
+        allow_bias: false
+        activation:
+          name: lrelu
+          negative_slope: 0.33
+        norm_layer:
+          name: batch_norm
+          eps: 0.0001
+          momentum: 0.01
+
+      ppn:
+        classify_endpoints: false
+
+    uresnet_ppn_loss:
+      uresnet_loss:
+        balance_loss: false
+
+      ppn_loss:
+        mask_loss: CE
+        resolution: 5.0
+
+    # Fragmentation
+    graph_spice:
+      shapes: [shower, track, michel, delta]
+      use_raw_features: true
+      invert: true
+      make_clusters: true
+      embedder:
+        spatial_embedding_dim: 3
+        feature_embedding_dim: 16
+        occupancy_mode: softplus
+        covariance_mode: softplus
+        uresnet:
+          num_input: 4 # 1 feature + 3 normalized coords
+          filters: 32
+          input_kernel: 5
+          depth: 5
+          reps: 2
+          spatial_size: 6144
+          allow_bias: false
+          activation:
+            name: lrelu
+            negative_slope: 0.33
+          norm_layer:
+            name: batch_norm
+            eps: 0.0001
+            momentum: 0.01
+      kernel:
+        name: bilinear
+        num_features: 32
+      constructor:
+        edge_threshold: 0.1
+        min_size: 3
+        label_edges: false
+        graph:
+          name: radius
+          r: 1.9
+        orphan:
+          mode: radius
+          radius: 1.9
+          iterate: true
+          assign_all: true
+
+    graph_spice_loss:
+      name: edge
+      loss: binary_log_dice_ce
+
+    # Shower aggregation
+    grappa_shower:
+      nodes:
+        source: cluster
+        shapes: [shower, michel, delta]
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: [500, 0, 500, 500, 0, 0, 0, 25, 0, 25]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred: 2
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_shower_loss:
+      node_loss:
+        name: shower_primary
+        use_closest: true
+        high_purity: true
+        use_group_pred: true
+      edge_loss:
+        name: channel
+        target: group
+        high_purity: true
+
+    # Track aggregation
+    grappa_track:
+      nodes:
+        source: cluster
+        shapes: [track]
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: 100
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: false
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 32 # 16 (geo) + 2 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_track_loss:
+      edge_loss:
+        name: channel
+        target: group
+
+    # Interaction aggregation, PID, primary, orientation
+    grappa_inter:
+      nodes:
+        source: group
+        shapes: [shower, track, michel, delta]
+        min_size: -1
+        make_groups: true
+      graph:
+        name: complete
+        max_length: [500, 500, 0, 0, 25, 25, 25, 0, 0, 0]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred:
+          type: 5
+          primary: 2
+          orient: 2
+          #momentum: 1
+          #vertex: 5
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_inter_loss:
+      node_loss:
+        type:
+          name: class
+          target: pid
+          loss: ce
+          balance_loss: true
+        primary:
+          name: class
+          target: inter_primary
+          loss: ce
+          balance_loss: true
+        orient:
+          name: orient
+          loss: ce
+      edge_loss:
+        name: channel
+        target: interaction
+
+# Build output representations
+build:
+  mode: reco
+  units: cm
+  fragments: false
+  particles: true
+  interactions: true
+  
+# Run post-processors
+post:
+  flash_match:
+    flash_key: flashes
+    volume: tpc
+    detector: sbnd
+    method: likelihood
+    cfg: flashmatch_240918.cfg
+    scaling: 1./555. # If reprocessing data that's already been scaled, use 1
+    alpha: 0.21 # Light yield calculation - https://arxiv.org/pdf/1909.07920
+    recombination_mip: 0.6 # 0.65 used in studies - https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=38164
+    priority: 3
+  shape_logic:
+    enforce_pid: true
+    enforce_primary: true
+    priority: 3
+  apply_calibrations:
+    geometry:
+      detector: sbnd
+    gain:
+      gain: [52.356, 52.356] #from data
+    recombination:
+      efield: 0.5 # kV/cm
+      model: mbox
+    lifetime:
+      lifetime: [50000, 50000] #us
+      driftv: [0.1563, 0.1563] #cm/us
+    priority: 2
+  direction:
+    run_mode: reco
+    obj_type: particle
+    optimize: true
+    priority: 1
+    neighborhood_radius: 60
+  calo_ke:
+    run_mode: reco
+    scaling: 1.
+    shower_fudge: 1/0.77
+    priority: 1
+  csda_ke:
+    run_mode: reco
+    tracking_mode: step_next
+    segment_length: 5.0
+    fill_per_pid: true
+    priority: 1
+  mcs_ke:
+    run_mode: reco
+    tracking_mode: bin_pca
+    segment_length: 14.0
+    fill_per_pid: true
+    priority: 1
+  containment:
+    run_mode: reco
+    detector: sbnd
+    mode: source
+    margin: 5.0
+    cathode_margin: -5.0
+    min_particle_sizes:
+      0: 25
+      1: 25
+    priority: 1
+  vertex:
+    use_primaries: true
+    update_primaries: false
+    priority: 1
+    run_mode: reco
+  topology_threshold:
+    run_mode: reco
+    ke_thresholds:
+      4: 50
+      default: 25
+      1: 25
+  fiducial:
+    run_mode: reco
+    detector: sbnd
+    mode: module
+    margin: [[20,20],[20,20],[10,50]] # TODO: add 5cm pad either side of the cathode


### PR DESCRIPTION
New weights for SBND training v02. Training was done on Polaris using the configs in the [sbnd_spine_train](https://github.com/bear-is-asleep/sbnd_spine_train/tree/master) repo.

# Tests

- [x] mc config
- [x] data config

# Sample Description

## Training Sample Generation March 4, 2025

This folder contains the training samples for MPVMPR using `sbndcode v10_04_01` which can be found [here](https://github.com/SBNSoftware/sbndcode/tree/v10_04_01) . The training samples are generated using the following fcls:
```
run_mpvmpr_sbnd.fcl
g4_sce_lite.fcl
detsim_sce_lite.fcl
reco1_mpvmpr.fcl
```

The following modifications were made to the `sbndcode` configuration:
- Ghost labeling parameters - [Supera PR #54](https://github.com/DeepLearnPhysics/Supera/pull/54)
- Doublets are used - [sbndcode PR #661](https://github.com/SBNSoftware/sbndcode/pull/661)
- Updated clock - [sbndcode PR #645](https://github.com/SBNSoftware/sbndcode/pull/645)
- `larwirecell` patch - [larwirecell PR #55](https://github.com/LArSoft/larwirecell/pull/55)

Training will use XXXX larcv files, each with 50 events = ** 255,200 events **.

## Caveats
- Training run 1 passed 5104/6000 events with following error codes:
  - `1` (896/6000) in `supera` stage. This is an issue from `v10` transition that causes about 0.3% of events to fail. [sbndcode issue #665](https://github.com/SBNSoftware/sbndcode/issues/665) is tracking this.