### PR TITLE
Data gain update 250508

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -484,7 +484,7 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [57.,57.] #from mc #[52.356,52.356] #from pandora data
+      gain: [49.529, 49.529] # from MC pandora  #[57.,57.] #from mc #[52.356,52.356] #from pandora data
     recombination:
       efield: 0.5 # kV/cm
       model: mbox

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -533,6 +533,17 @@ post:
     ke_thresholds:
       4: 50
       default: 25
+  start_dedx:
+    radius: 3.0
+    mode: default
+  start_straightness:
+    radius: 3.0
+    n_components: 3
+  particle_spread:
+    start_mode: start_point
+    use_start_dir: false
+  shower_conversion_distance:
+    mode: vertex_to_points
   fiducial:
     detector: sbnd
     mode: module

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -501,7 +501,7 @@ post:
   calo_ke:
     run_mode: both
     scaling: 1.
-    shower_fudge: 1/0.77 # previous:  1/0.83
+    shower_fudge: 1/0.762 # previous:  1/0.77
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -501,7 +501,7 @@ post:
   calo_ke:
     run_mode: both
     scaling: 1.
-    shower_fudge: 1/0.762 # previous:  1/0.77
+    shower_fudge: 1/0.763 # previous:  1/0.77
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -451,7 +451,7 @@ post:
   calo_ke:
     run_mode: reco
     scaling: 1.
-    shower_fudge: 1/0.762
+    shower_fudge: 1/0.763
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -434,7 +434,7 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [49.529, 49.529] #from MC pandora #[52.356, 52.356] #previous from data
+      gain: [47.55, 47.55] #from data Pandora - https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40834
     recombination:
       efield: 0.5 # kV/cm
       model: mbox

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -486,6 +486,17 @@ post:
       4: 50
       default: 25
       1: 25
+  start_dedx:
+    radius: 3.0
+    mode: default
+  start_straightness:
+    radius: 3.0
+    n_components: 3
+  particle_spread:
+    start_mode: start_point
+    use_start_dir: false
+  shower_conversion_distance:
+    mode: vertex_to_points
   fiducial:
     run_mode: reco
     detector: sbnd

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -434,7 +434,7 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [52.356, 52.356] #from data
+      gain: [49.529, 49.529] #from MC pandora #[52.356, 52.356] #previous from data
     recombination:
       efield: 0.5 # kV/cm
       model: mbox

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -451,7 +451,7 @@ post:
   calo_ke:
     run_mode: reco
     scaling: 1.
-    shower_fudge: 1/0.77
+    shower_fudge: 1/0.762
     priority: 1
   csda_ke:
     run_mode: reco


### PR DESCRIPTION
SBND data gain updated for Pandora-based gain value (**47.55** now for data). Link to the docdb:
[SBN-doc-40834-v3](https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=40834&filename=20250424_2025A_dev_chi2_and_hit.pdf&version=3)