### PR TITLE
Update batch size in SBND

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -14,7 +14,7 @@ base:
 # IO configuration
 io:
   loader:
-    batch_size: 16
+    batch_size: 8
     shuffle: false
     num_workers: 8
     collate_fn: all

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -14,7 +14,7 @@ base:
 # IO configuration
 io:
   loader:
-    batch_size: 16
+    batch_size: 8
     shuffle: false
     num_workers: 8
     collate_fn: all


### PR DESCRIPTION
CUDA memory often runs out using batch size 16.