### PR TITLE
NERSC + `ND_Production` Compatible Version of `ndlar_full_chain_nersc_250505`

### DIFF
--- a/config/ndlar/ndlar_full_chain_nersc_250505.cfg
+++ b/config/ndlar/ndlar_full_chain_nersc_250505.cfg
@@ -9,7 +9,7 @@ base:
   prefix_log: true
   overwrite_log: true
   log_step: 1
-  split_output: true
+  split_output: false
 
 # IO configuration
 io:

--- a/config/ndlar/ndlar_full_chain_nersc_250505.cfg
+++ b/config/ndlar/ndlar_full_chain_nersc_250505.cfg
@@ -1,0 +1,499 @@
+# Base configuration
+base:
+  world_size: 1
+  iterations: -1
+  seed: 0
+  dtype: float32
+  unwrap: true
+  log_dir: %TMPDIR%/log_trash
+  prefix_log: true
+  overwrite_log: true
+  log_step: 1
+  split_output: true
+
+# IO configuration
+io:
+  loader:
+    batch_size: 4
+    shuffle: false
+    num_workers: 8
+    collate_fn: all
+    dataset:
+      name: larcv
+      file_keys: null
+      schema:
+        data:
+          parser: sparse3d
+          sparse_event: sparse3d_pcluster
+        seg_label:
+          parser: sparse3d
+          sparse_event: sparse3d_pcluster_semantics
+        ppn_label:
+          parser: particle_points
+          sparse_event: sparse3d_pcluster
+          particle_event: particle_pcluster
+          include_point_tagging: false
+        clust_label:
+          parser: cluster3d
+          cluster_event: cluster3d_pcluster
+          particle_event: particle_pcluster
+          neutrino_event: neutrino_mc_truth
+          sparse_semantics_event: sparse3d_pcluster_semantics
+          add_particle_info: true
+          clean_data: true
+        coord_label:
+          parser: particle_coords
+          particle_event: particle_pcluster
+          cluster_event: cluster3d_pcluster
+        #graph_label:
+        #  parser: particle_graph
+        #  particle_event: particle_pcluster
+        particles:
+          parser: particle
+          particle_event: particle_pcluster
+          neutrino_event: neutrino_mc_truth
+          cluster_event: cluster3d_pcluster
+          skip_empty: true
+        neutrinos:
+          parser: neutrino
+          neutrino_event: neutrino_mc_truth
+          cluster_event: cluster3d_pcluster
+        meta:
+          parser: meta
+          sparse_event: sparse3d_pcluster
+        run_info:
+          parser: run_info
+          sparse_event: sparse3d_pcluster
+        trigger:
+          parser: trigger
+          trigger_event: trigger_base
+        flashes:
+          parser: flash
+          flash_event: opflash_light
+
+  writer:
+    name: hdf5
+    file_name: null
+    overwrite: true
+    keys:
+      - run_info
+      - meta
+      - trigger
+      - flashes
+      - points
+      - points_label
+      - depositions
+      - depositions_label
+      - reco_particles
+      - truth_particles
+      - reco_interactions
+      - truth_interactions
+
+# Model configuration
+model:
+  name: full_chain
+  weight_path: /dvs_ro/cfs/projectdirs/dune/users/drielsma/weights/ndlar_250505_snapshot.ckpt
+  to_numpy: true
+
+  network_input:
+    data: data
+    seg_label: seg_label
+
+  modules:
+    # General chain configuration
+    chain:
+      deghosting: null
+      charge_rescaling: null
+      segmentation: uresnet
+      point_proposal: ppn
+      fragmentation: graph_spice
+      shower_aggregation: grappa
+      shower_primary: grappa
+      track_aggregation: grappa
+      particle_aggregation: null
+      inter_aggregation: grappa
+      particle_identification: grappa
+      primary_identification: grappa
+      orientation_identification: grappa
+      calibration: null
+
+    # Semantic segmentation + point proposal
+    uresnet_ppn:
+      uresnet:
+        num_input: 1
+        num_classes: 5
+        filters: 32
+        depth: 5
+        reps: 2
+        allow_bias: false
+        activation:
+          name: lrelu
+          negative_slope: 0.33
+        norm_layer:
+          name: batch_norm
+          eps: 0.0001
+          momentum: 0.01
+
+      ppn:
+        classify_endpoints: false
+
+    uresnet_ppn_loss:
+      uresnet_loss:
+        balance_loss: false
+
+      ppn_loss:
+        mask_loss: CE
+        resolution: 5.0
+
+    # Dense clustering
+    graph_spice:
+      shapes: [shower, track, michel, delta]
+      use_raw_features: true
+      invert: true
+      make_clusters: true
+      embedder:
+        spatial_embedding_dim: 3
+        feature_embedding_dim: 16
+        occupancy_mode: softplus
+        covariance_mode: softplus
+        uresnet:
+          num_input: 4 # 1 feature + 3 normalized coords
+          filters: 32
+          input_kernel: 5
+          depth: 5
+          reps: 2
+          spatial_size: 6144
+          allow_bias: false
+          activation:
+            name: lrelu
+            negative_slope: 0.33
+          norm_layer:
+            name: batch_norm
+            eps: 0.0001
+            momentum: 0.01
+      kernel:
+        name: bilinear
+        num_features: 32
+      constructor:
+        edge_threshold: 0.1
+        min_size: 3
+        label_edges: false
+        graph:
+          name: radius
+          r: 1.9
+        orphan:
+          mode: radius
+          radius: 1.9
+          iterate: true
+          assign_all: true
+
+    graph_spice_loss:
+      name: edge
+      loss: binary_log_dice_ce
+
+    # Shower fragment aggregation + shower primary identification
+    grappa_shower:
+      nodes:
+        source: cluster
+        shapes: [shower, michel, delta]
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: [500, 0, 500, 500, 0, 0, 0, 25, 0, 25]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred: 2
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_shower_loss:
+      node_loss:
+        name: shower_primary
+        use_closest: true
+        high_purity: true
+        use_group_pred: true
+      edge_loss:
+        name: channel
+        target: group
+        high_purity: true
+
+    # Track aggregation
+    grappa_track:
+      nodes:
+        source: cluster
+        shapes: [track]
+        make_groups: true
+        grouping_method: score
+      graph:
+        name: complete
+        max_length: 100
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: false
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 32 # 16 (geo) + 2 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 64
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_track_loss:
+      edge_loss:
+        name: channel
+        target: group
+
+    # Interaction aggregation, PID, primary, orientation
+    grappa_inter:
+      nodes:
+        source: group
+        shapes: [shower, track, michel, delta]
+        min_size: -1
+        make_groups: true
+      graph:
+        name: complete
+        max_length: [500, 500, 0, 0, 25, 25, 25, 0, 0, 0]
+        dist_algorithm: recursive
+      node_encoder:
+        name: geo
+        use_numpy: true
+        add_value: true
+        add_shape: true
+        add_points: true
+        add_local_dirs: true
+        dir_max_dist: 5
+        add_local_dedxs: true
+        dedx_max_dist: 5
+      edge_encoder:
+        name: geo
+        use_numpy: true
+      gnn_model:
+        name: meta
+        node_feats: 33 # 16 (geo) + 3 (extra) + 6 (points) + 6 (directions) + 2 (local dedxs)
+        edge_feats: 19
+        node_pred:
+          type: 6 # With kaon!
+          primary: 2
+          orient: 2
+          #momentum: 1
+          #vertex: 5
+        edge_pred: 2
+        edge_layer:
+          name: mlp
+          mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+        node_layer:
+          name: mlp
+          reduction: max
+          attention: false
+          message_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+          aggr_mlp:
+            depth: 3
+            width: 128
+            activation:
+              name: lrelu
+              negative_slope: 0.1
+            normalization: batch_norm
+
+    grappa_inter_loss:
+      node_loss:
+        type:
+          name: class
+          target: pid
+          loss: ce
+          balance_loss: true
+        primary:
+          name: class
+          target: inter_primary
+          loss: ce
+          balance_loss: true
+        orient:
+          name: orient
+          loss: ce
+        #momentum:
+        #  name: reg
+        #  target: momentum
+        #  loss: berhu
+        #vertex:
+        #  name: vertex
+        #  primary_loss: ce
+        #  balance_primary_loss: true
+        #  regression_loss: mse
+        #  only_contained: true
+        #  normalize_positions: true
+        #  use_anchor_points: true
+        #  return_vertex_labels: true
+        #  detector: icarus
+      edge_loss:
+        name: channel
+        target: interaction
+
+# Build output representations
+build:
+  mode: both
+  units: cm
+  fragments: false
+  particles: true
+  interactions: true
+  
+# Run post-processors
+post:
+  shape_logic:
+    enforce_pid: true
+    enforce_primary: true
+    priority: 3
+  #particle_threshold:
+  #  track_pid_thresholds:
+  #    4: 0.85
+  #    2: 0.1
+  #    3: 0.5
+  #    5: 0.0
+  #  shower_pid_thresholds:
+  #    0: 0.5 
+  #    1: 0.0
+  #  primary_threshold: 0.1
+  #  priority: 2
+  #track_extrema:
+  #  method: gradient
+  #  priority: 2
+  direction:
+    run_mode: reco
+    obj_type: particle
+    optimize: true
+    priority: 1
+    radius: 60
+  calo_ke:
+    run_mode: both
+    scaling: 1.
+    shower_fudge: 1/0.83
+    priority: 1
+  csda_ke:
+    run_mode: reco
+    tracking_mode: step_next
+    segment_length: 5.0
+    priority: 1
+  mcs_ke:
+    run_mode: reco
+    tracking_mode: bin_pca
+    segment_length: 5.0
+  containment:
+    run_mode: both
+    detector: ndlar
+    margin: 5.0
+    mode: detector
+    priority: 1
+  vertex:
+    run_mode: reco
+    use_primaries: true
+    update_primaries: false
+    priority: 1
+    priority: 1
+  topology_threshold:
+    run_mode: both
+    ke_thresholds:
+      4: 50
+      default: 25
+  fiducial:
+    run_mode: both
+    detector: ndlar
+    margin: 15.0
+    mode: detector
+  children_count:
+    mode: shape
+  match:
+    match_mode: both
+    ghost: false
+    truth_point_mode: points
+    fragment: false
+    particle: true
+    interaction: true


### PR DESCRIPTION
Equivalent to `ndlar_full_chain_nersc_250505.cfg` but with a tweaked batch size, `ND_Production` logging logic / file naming and NERSC weights paths.

Fully tested.