### PR TITLE
Add new weights

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -122,8 +122,8 @@ io:
 # Model configuration
 model:
   name: full_chain
-  weight_path: /sdf/data/neutrino/sbnd/train/mpvmpr_v02/weights/full_chain/restrict/snapshot-4999.ckpt #s3df
-  #weight_path: /lus/eagle/projects/neutrinoGPU/bearc/spine_weights/mpvmpr_v02/weights/full_chain/grappa_inter/default/snapshot-4999.ckpt #polaris
+  weight_path: /sdf/data/neutrino/sbnd/train/mpvmpr_v02/weights/full_chain/restrict_250516/snapshot-6499.ckpt #s3df
+  #weight_path: /lus/eagle/projects/neutrinoGPU/bearc/spine_weights/mpvmpr_v02/weights/full_chain/grappa_inter/restrict_250516/snapshot-6499.ckpt #polaris
   to_numpy: true
 
   network_input:

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -74,8 +74,8 @@ io:
 # Model configuration
 model:
   name: full_chain
-  weight_path: /sdf/data/neutrino/sbnd/train/mpvmpr_v02/weights/full_chain/restrict/snapshot-4999.ckpt #s3df
-  #weight_path: /lus/eagle/projects/neutrinoGPU/bearc/spine_weights/mpvmpr_v02/weights/full_chain/grappa_inter/default/snapshot-4999.ckpt #polaris
+  weight_path: /sdf/data/neutrino/sbnd/train/mpvmpr_v02/weights/full_chain/restrict_250516/snapshot-6499.ckpt #s3df
+  #weight_path: /lus/eagle/projects/neutrinoGPU/bearc/spine_weights/mpvmpr_v02/weights/full_chain/grappa_inter/restrict_250516/snapshot-6499.ckpt #polaris
   to_numpy: true
 
   network_input:


### PR DESCRIPTION
Updated training uses MPR that also originate outside the detector. This corrects for bias in direction in the training sample. See [sbndcode PR](https://github.com/SBNSoftware/sbndcode/pull/726) for more info.

![image](https://github.com/user-attachments/assets/b680c8ee-66fc-4a6a-986c-9e0061b3c055)
![image](https://github.com/user-attachments/assets/9c1f6107-2f1b-4215-9e77-a04cba917961)
