### PR TITLE
Add sbnd_full_chain config files for shower quality attributes

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -546,3 +546,14 @@ post:
     fragment: false
     particle: true
     interaction: true
+  start_dedx:
+    radius: 3.0
+    mode: default
+  start_straightness:
+    radius: 3.0
+    n_components: 3
+  particle_spread:
+    start_mode: start_point
+    use_start_dir: false
+  shower_conversion_distance:
+    mode: vertex_to_points

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -491,3 +491,14 @@ post:
     detector: sbnd
     mode: module
     margin: [[20,20],[20,20],[10,50]] # TODO: add 5cm pad either side of the cathode
+  start_dedx:
+    radius: 3.0
+    mode: default
+  start_straightness:
+    radius: 3.0
+    n_components: 3
+  particle_spread:
+    start_mode: start_point
+    use_start_dir: false
+  shower_conversion_distance:
+    mode: vertex_to_points


### PR DESCRIPTION
The shower quality cut attributes were added back. Two of the configs were updated:

- config/sbnd/sbnd_full_chain_250328.cfg
- config/sbnd/sbnd_full_chain_data_250328.cfg