### PR TITLE
Update lifetime correction used in SBND calibration post-processor

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -489,7 +489,7 @@ post:
       efield: 0.5 # kV/cm
       model: mbox
     lifetime:
-      lifetime: [50000, 50000] #us
+      lifetime: [100000, 100000] #us
       driftv: [0.1563, 0.1563] #cm/us
     priority: 2
   direction:

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -439,7 +439,7 @@ post:
       efield: 0.5 # kV/cm
       model: mbox
     lifetime:
-      lifetime: [50000, 50000] #us
+      lifetime: [100000, 100000] #us
       driftv: [0.1563, 0.1563] #cm/us
     priority: 2
   direction:


### PR DESCRIPTION
Update lifetime correction from 50 ms to 100 ms (which is simulated in sbndcode)