### PR TITLE
Update SBND MCS

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -514,6 +514,8 @@ post:
     tracking_mode: bin_pca
     segment_length: 14.0
     fill_per_pid: true
+    res_a: 0.315
+    res_b: 1.197
     priority: 1
   containment:
     detector: sbnd

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -464,6 +464,8 @@ post:
     tracking_mode: bin_pca
     segment_length: 14.0
     fill_per_pid: true
+    res_a: 0.315
+    res_b: 1.197
     priority: 1
   containment:
     run_mode: reco


### PR DESCRIPTION
Used 10k 100 GeV muons to derive angular resolution. The angular resolution is computed as a function of segment length, which is of the form a / x^b. b and a are fitted to using this sample. The resolution is $\theta_0$, which is used in the Highland formula.

![image](https://github.com/user-attachments/assets/39c7ab75-be7c-456f-96a1-294eb16602c1)
