### PR TITLE
Update calibration constants for SBND MC and data

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -484,7 +484,7 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [49.826 , 49.826 ] # from MC pandora 
+      gain: [49.826 , 49.826 ] #e/adc 
     recombination:
       efield: 0.5 # kV/cm
       model: mbox

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -501,7 +501,7 @@ post:
   calo_ke:
     run_mode: both
     scaling: 1.
-    shower_fudge: 1/0.763
+    shower_fudge: 1.303 # updated fudge = old_fudge * (old_mc_gain / new_mc_gain) = (1/0.763) * (49.529/49.826)
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -501,7 +501,7 @@ post:
   calo_ke:
     run_mode: both
     scaling: 1.
-    shower_fudge: 1.303 # updated fudge = old_fudge * (old_mc_gain / new_mc_gain) = (1/0.763) * (49.529/49.826)
+    shower_fudge: 1.306
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -484,12 +484,12 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [49.529, 49.529] # from MC pandora 
+      gain: [49.826 , 49.826 ] # from MC pandora 
     recombination:
       efield: 0.5 # kV/cm
       model: mbox
     lifetime:
-      lifetime: [50000, 50000] #us
+      lifetime: [100000, 100000] #us
       driftv: [0.1563, 0.1563] #cm/us
     priority: 2
   direction:

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -451,7 +451,7 @@ post:
   calo_ke:
     run_mode: reco
     scaling: 1.
-    shower_fudge: 1/0.763
+    shower_fudge: 1.303 # updated fudge = old_fudge * (old_mc_gain / new_mc_gain) = (1/0.763) * (49.529/49.826)
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -434,12 +434,12 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [47.55, 47.55] #from data Pandora - https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40834
+      gain: [46.533, 46.533] #from data Pandora - https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40834
     recombination:
       efield: 0.5 # kV/cm
       model: mbox
     lifetime:
-      lifetime: [50000, 50000] #us
+      lifetime: [35000, 35000] #us
       driftv: [0.1563, 0.1563] #cm/us
     priority: 2
   direction:

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -451,7 +451,7 @@ post:
   calo_ke:
     run_mode: reco
     scaling: 1.
-    shower_fudge: 1.303 # updated fudge = old_fudge * (old_mc_gain / new_mc_gain) = (1/0.763) * (49.529/49.826)
+    shower_fudge: 1.306
     priority: 1
   csda_ke:
     run_mode: reco

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -434,7 +434,7 @@ post:
     geometry:
       detector: sbnd
     gain:
-      gain: [46.533, 46.533] #from data Pandora - https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40834
+      gain: [46.533, 46.533] #e/adc
     recombination:
       efield: 0.5 # kV/cm
       model: mbox


### PR DESCRIPTION
MC electron lifetime:  100 ms
data electron lifetime:  35 ms (for dev sample)
MC gain value:  1/(0.02007 ADC/e-)   --->   49.826 e-/ADC
data gain value:  1/(0.02149 ADC/e-)   --->  46.533 e-/ADC

shower correction = 1.303 
(old_correction * (old_mc_gain / new_mc_gain) = (1/0.763) * (49.529/49.826))