### PR TITLE
Add cathode crosser post processor, update vertexing for track start/end

### DIFF
--- a/config/sbnd/sbnd_full_chain_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_250328.cfg
@@ -466,6 +466,15 @@ build:
   
 # Run post-processors
 post:
+  cathode_crosser:
+    run_mode: reco
+    detector: sbnd
+    crossing_point_tolerance: 565.685
+    offset_tolerance: 15
+    angle_tolerance: 0.26
+    adjust_crossers: True
+    merge_crossers: True
+    priority: 4
   flash_match:
     flash_key: flashes
     volume: tpc
@@ -496,7 +505,7 @@ post:
     obj_type: particle
     optimize: true
     run_mode: reco
-    priority: 1
+    priority: 5
     radius: 60
   calo_ke:
     run_mode: both
@@ -527,7 +536,8 @@ post:
   vertex:
     use_primaries: true
     update_primaries: false
-    priority: 1
+    update_orientations: true
+    priority: 2
     run_mode: reco
   topology_threshold:
     ke_thresholds:

--- a/config/sbnd/sbnd_full_chain_data_250328.cfg
+++ b/config/sbnd/sbnd_full_chain_data_250328.cfg
@@ -416,6 +416,15 @@ build:
   
 # Run post-processors
 post:
+  cathode_crosser:
+    run_mode: reco
+    detector: sbnd
+    crossing_point_tolerance: 565.685
+    offset_tolerance: 15
+    angle_tolerance: 0.26
+    adjust_crossers: True
+    merge_crossers: True
+    priority: 4
   flash_match:
     flash_key: flashes
     volume: tpc
@@ -446,7 +455,7 @@ post:
     run_mode: reco
     obj_type: particle
     optimize: true
-    priority: 1
+    priority: 5
     radius: 60
   calo_ke:
     run_mode: reco
@@ -478,7 +487,8 @@ post:
   vertex:
     use_primaries: true
     update_primaries: false
-    priority: 1
+    update_orientations: true
+    priority: 2
     run_mode: reco
   topology_threshold:
     run_mode: reco


### PR DESCRIPTION
**Needs testing before merging**

Merge obvious cathode crossers into single particles. Based on their angular alignment and distance from the cathode, use default values from calibration studies, but allow the absolute separation to be large in yz.

<img width="759" height="350" alt="image" src="https://github.com/user-attachments/assets/c171a4dc-afbd-4f8b-a15b-1caf480e2042" />
