### PR TITLE
Change `split_output` Setting to `false` in `base_common.yaml` For NDLAr

### DIFF
--- a/config/infer/nd-lar/base/base_common.yaml
+++ b/config/infer/nd-lar/base/base_common.yaml
@@ -11,7 +11,7 @@ base:
   prefix_log: true
   overwrite_log: true
   log_step: 1
-  split_output: true
+  split_output: false
 
 # Geometry configuration
 geo:


### PR DESCRIPTION
I couldn't work out how to not trigger [this](https://github.com/DeepLearnPhysics/spine/blob/73daa06f1c8b6e00421b8c3d4268f8037998f590/src/spine/io/core/write/hdf5.py#L97) `else` instead of the `if` , namely, not add a prefix to the outfile name based on the infile name. `prefix` gets filled [here](https://github.com/DeepLearnPhysics/spine/blob/73daa06f1c8b6e00421b8c3d4268f8037998f590/src/spine/driver.py#L451) regardless when you are working with just one input file (which we are with production at the moment) because of [this](https://github.com/DeepLearnPhysics/spine/blob/73daa06f1c8b6e00421b8c3d4268f8037998f590/src/spine/driver.py#L500) line. Changing `split_output` to `false` gives the desired behaviour.